### PR TITLE
Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 vendor
 build/log
 build/docs
+build/dist
 tmp

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ md:
 
 cov:
 	phpunit --coverage-html=build/log/coverage
+	open build/log/coverage/index.html
 
 pear:
 	./build/pear/package.php --source=src/ --version=$(version) > package.xml

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,6 @@ cov:
 pear:
 	./build/pear/package.php --source=src/ --version=$(version) > package.xml
 	pear package
-	mv VirtualFileSystem-$(version).tgz ../pear.thornag.github.io/
-	cd ../pear.thornag.github.io && /usr/local/opt/php55/bin/pirum add . VirtualFileSystem-$(version).tgz
+	mv VirtualFileSystem-$(version).tgz build/dist/
+	/usr/local/opt/php55/bin/pirum add ../pear.thornag.github.io build/dist/VirtualFileSystem-$(version).tgz
 	cd ../pear.thornag.github.io && git add . && git commit -a -m'adding VirtualFileSystem-$(version).tgz' && git push

--- a/src/VirtualFileSystem/Container.php
+++ b/src/VirtualFileSystem/Container.php
@@ -38,6 +38,11 @@ class Container
     protected $factory;
 
     /**
+     * @var Wrapper\PermissionHelper
+     */
+    protected $permission_helper;
+
+    /**
      * Class constructor. Sets factory and root object on init.
      *
      * @param Factory $factory
@@ -46,6 +51,7 @@ class Container
     {
         $this->setFactory($factory);
         $this->root = $this->factory()->getRoot();
+        $this->setPermissionHelper(new Wrapper\PermissionHelper());
     }
 
     /**
@@ -240,5 +246,27 @@ class Container
         }
 
         $this->fileAt(dirname($path))->remove(basename($path));
+    }
+
+    /**
+     * Returns PermissionHelper with given node in context
+     *
+     * @param Structure\Node $node
+     *
+     * @return \VirtualFileSystem\Wrapper\PermissionHelper
+     */
+    public function getPermissionHelper(Structure\Node $node)
+    {
+        return $this->permission_helper->setNode($node);
+    }
+
+    /**
+     * Sets permission helper instance
+     *
+     * @param \VirtualFileSystem\Wrapper\PermissionHelper $permission_helper
+     */
+    public function setPermissionHelper($permission_helper)
+    {
+        $this->permission_helper = $permission_helper;
     }
 }

--- a/src/VirtualFileSystem/Factory.php
+++ b/src/VirtualFileSystem/Factory.php
@@ -34,8 +34,8 @@ class Factory
      */
     public function __construct()
     {
-        $this->userid = posix_getuid();
-        $this->groupid = posix_getgid();
+        $this->userid = function_exists('posix_getuid') ? posix_getuid() : 0;
+        $this->groupid = function_exists('posix_getgid') ? posix_getgid() : 0;
     }
 
     /**

--- a/src/VirtualFileSystem/Wrapper.php
+++ b/src/VirtualFileSystem/Wrapper.php
@@ -151,7 +151,7 @@ class Wrapper
                 return false;
             }
             $parent = $container->fileAt(dirname($path));
-            $ph = new PermissionHelper($parent);
+            $ph = $container->getPermissionHelper($parent);
             if (!$ph->isWritable()) {
                 return $permissionDeniedError();
             }
@@ -175,7 +175,7 @@ class Wrapper
             $file->chgrp($dir->group());
         }
 
-        $permissionHelper = new PermissionHelper($file);
+        $permissionHelper = $container->getPermissionHelper($file);
 
         $this->currently_opened = new FileHandler();
         $this->currently_opened->setFile($file);
@@ -322,7 +322,7 @@ class Wrapper
             while ($parentPath = dirname($parentPath)) {
                 try {
                     $parent = $container->fileAt($parentPath);
-                    $ph = new PermissionHelper($parent);
+                    $ph = $container->getPermissionHelper($parent);
                     if (!$ph->isWritable()) {
                         trigger_error(sprintf('mkdir: %s: Permission denied', dirname($path)), E_USER_WARNING);
                         return false;
@@ -388,7 +388,7 @@ class Wrapper
             $container = $this->getContainerFromContext($path);
             $strippedPath = $this->stripScheme($path);
             $node = $container->fileAt($strippedPath);
-            $ph = new PermissionHelper($node);
+            $ph = $container->getPermissionHelper($node);
 
             switch ($option) {
                 case STREAM_META_ACCESS:
@@ -550,7 +550,7 @@ class Wrapper
 
             $parent = $container->fileAt(dirname($path));
 
-            $ph = new PermissionHelper($parent);
+            $ph = $container->getPermissionHelper($parent);
             if (!$ph->isWritable()) {
                 trigger_error(
                     sprintf('rm: %s: Permission denied', $path),
@@ -600,7 +600,7 @@ class Wrapper
                 return false;
             }
 
-            $ph = new PermissionHelper($directory);
+            $ph = $container->getPermissionHelper($directory);
             if (!$ph->isReadable()) {
                 trigger_error(
                     sprintf('rmdir: %s: Permission denied', $path),
@@ -641,6 +641,7 @@ class Wrapper
     public function dir_opendir($path, $options)
     {
         $container = $this->getContainerFromContext($path);
+
         $path = $this->stripScheme($path);
 
         if (!$container->hasFileAt($path)) {
@@ -655,7 +656,7 @@ class Wrapper
             return false;
         }
 
-        $permissionHelper = new PermissionHelper($dir);
+        $permissionHelper = $container->getPermissionHelper($dir);
 
         if (!$permissionHelper->isReadable()) {
             trigger_error(sprintf('opendir(%s): failed to open dir: Permission denied', $path), E_USER_WARNING);

--- a/src/VirtualFileSystem/Wrapper.php
+++ b/src/VirtualFileSystem/Wrapper.php
@@ -424,7 +424,7 @@ class Wrapper
                         );
                         return false;
                     }
-                    $uid = posix_getpwnam($value)['uid'];
+                    $uid = function_exists('posix_getpwnam') ? posix_getpwnam($value)['uid'] : 0;
                     $node->chown($uid);
                     $node->setChangeTime(time());
                     break;
@@ -449,7 +449,7 @@ class Wrapper
                         );
                         return false;
                     }
-                    $gid = posix_getgrnam($value)['gid'];
+                    $gid = function_exists('posix_getgrnam') ? posix_getgrnam($value)['gid'] : 0;
                     $node->chgrp($gid);
                     $node->setChangeTime(time());
                     break;

--- a/src/VirtualFileSystem/Wrapper/PermissionHelper.php
+++ b/src/VirtualFileSystem/Wrapper/PermissionHelper.php
@@ -133,4 +133,14 @@ class PermissionHelper
     {
         return $this->userCanWrite() || $this->groupCanWrite() || $this->worldCanWrite();
     }
+
+    /**
+     * Checks whether userid is 0 - root.
+     *
+     * @return bool
+     */
+    public function userIsRoot()
+    {
+        return $this->userid == 0;
+    }
 }

--- a/src/VirtualFileSystem/Wrapper/PermissionHelper.php
+++ b/src/VirtualFileSystem/Wrapper/PermissionHelper.php
@@ -30,8 +30,8 @@ class PermissionHelper
      */
     public function __construct($uid = null, $gid = null)
     {
-        $this->userid = is_null($uid) ? posix_getuid() : $uid;
-        $this->groupid = is_null($gid) ? posix_getgid() : $gid;
+        $this->userid = is_null($uid) ? (function_exists('posix_getuid') ? posix_getuid() : 0) : $uid;
+        $this->groupid = is_null($gid) ? ((function_exists('posix_getgid') ? posix_getgid() : 0)) : $gid;
     }
 
     /**

--- a/src/VirtualFileSystem/Wrapper/PermissionHelper.php
+++ b/src/VirtualFileSystem/Wrapper/PermissionHelper.php
@@ -25,13 +25,13 @@ class PermissionHelper
     protected $groupid;
 
     /**
-     * @param Node $node
+     * @param int $uid
+     * @param int $gid
      */
-    public function __construct(Node $node)
+    public function __construct($uid = null, $gid = null)
     {
-        $this->node = $node;
-        $this->userid = posix_getuid();
-        $this->groupid = posix_getgid();
+        $this->userid = is_null($uid) ? posix_getuid() : $uid;
+        $this->groupid = is_null($gid) ? posix_getgid() : $gid;
     }
 
     /**
@@ -142,5 +142,16 @@ class PermissionHelper
     public function userIsRoot()
     {
         return $this->userid == 0;
+    }
+
+    /**
+     * @param \VirtualFileSystem\Structure\Node $node
+     *
+     * @return PermissionHelper
+     */
+    public function setNode($node)
+    {
+        $this->node = $node;
+        return $this;
     }
 }

--- a/tests/VirtualFileSystem/Wrapper/PermissionHelperTest.php
+++ b/tests/VirtualFileSystem/Wrapper/PermissionHelperTest.php
@@ -13,7 +13,8 @@ class PermissionHelperTest extends \PHPUnit_Framework_TestCase
         $file = new File('file');
         $file->chown(posix_getuid());
 
-        $ph = new PermissionHelper($file);
+        $ph = new PermissionHelper();
+        $ph->setNode($file);
 
         $file->chmod(0000);
         $this->assertFalse($ph->userCanRead(), 'User can\'t read with 0000');
@@ -51,7 +52,8 @@ class PermissionHelperTest extends \PHPUnit_Framework_TestCase
         $file = new File('file');
         $file->chgrp(posix_getgid());
 
-        $ph = new PermissionHelper($file);
+        $ph = new PermissionHelper();
+        $ph->setNode($file);
 
         $file->chmod(0000);
         $this->assertFalse($ph->groupCanRead(), 'group can\'t read with 0000');
@@ -88,7 +90,8 @@ class PermissionHelperTest extends \PHPUnit_Framework_TestCase
     {
         $file = new File('file');
 
-        $ph = new PermissionHelper($file);
+        $ph = new PermissionHelper();
+        $ph->setNode($file);
 
         $file->chmod(0000);
         $this->assertFalse($ph->worldCanRead(), 'world can\'t read with 0000');
@@ -120,7 +123,8 @@ class PermissionHelperTest extends \PHPUnit_Framework_TestCase
     {
         $file = new File('file');
 
-        $ph = new PermissionHelper($file);
+        $ph = new PermissionHelper();
+        $ph->setNode($file);
 
         $file->chmod(0000);
         $file->chown(0);

--- a/tests/VirtualFileSystem/Wrapper/PermissionHelperTest.php
+++ b/tests/VirtualFileSystem/Wrapper/PermissionHelperTest.php
@@ -7,11 +7,19 @@ use VirtualFileSystem\Structure\File;
 
 class PermissionHelperTest extends \PHPUnit_Framework_TestCase
 {
+    protected $uid;
+    protected $gid;
+
+    public function setUp() {
+        $this->uid = function_exists('posix_getuid') ? posix_getuid() : 0;
+        $this->gid = function_exists('posix_getgid') ? posix_getgid() : 0;
+    }
 
     public function testUserPermissionsAreCalculatedCorrectly()
     {
+
         $file = new File('file');
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
 
         $ph = new PermissionHelper();
         $ph->setNode($file);
@@ -50,7 +58,7 @@ class PermissionHelperTest extends \PHPUnit_Framework_TestCase
     public function testGroupPermissionsAreCalculatedCorrectly()
     {
         $file = new File('file');
-        $file->chgrp(posix_getgid());
+        $file->chgrp($this->gid);
 
         $ph = new PermissionHelper();
         $ph->setNode($file);
@@ -147,43 +155,43 @@ class PermissionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($ph->isReadable(), 'File is readable root:root 0004');
 
         $file->chmod(0000);
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
         $file->chgrp(0);
         $this->assertFalse($ph->isReadable(), 'File is not readable user:root 0000');
 
         $file->chmod(0400);
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
         $file->chgrp(0);
         $this->assertTrue($ph->isReadable(), 'File is readable user:root 0400');
 
         $file->chmod(0040);
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
         $file->chgrp(0);
         $this->assertFalse($ph->isReadable(), 'File is not readable user:root 0040');
 
         $file->chmod(0004);
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
         $file->chgrp(0);
         $this->assertTrue($ph->isReadable(), 'File is readable user:root 0004');
 
         $file->chmod(0000);
         $file->chown(0);
-        $file->chgrp(posix_getgid());
+        $file->chgrp($this->gid);
         $this->assertFalse($ph->isReadable(), 'File is not readable root:user 0000');
 
         $file->chmod(0040);
         $file->chown(0);
-        $file->chgrp(posix_getgid());
+        $file->chgrp($this->gid);
         $this->assertTrue($ph->isReadable(), 'File is readable root:user 0040');
 
         $file->chmod(0400);
         $file->chown(0);
-        $file->chgrp(posix_getgid());
+        $file->chgrp($this->gid);
         $this->assertFalse($ph->isReadable(), 'File is not readable root:user 0400');
 
         $file->chmod(0004);
         $file->chown(0);
-        $file->chgrp(posix_getgid());
+        $file->chgrp($this->gid);
         $this->assertTrue($ph->isReadable(), 'File is readable root:user 0004');
     }
 }

--- a/tests/VirtualFileSystem/WrapperTest.php
+++ b/tests/VirtualFileSystem/WrapperTest.php
@@ -103,6 +103,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
         }
 
         $fs = new FileSystem();
+        $fs->container()->setPermissionHelper(new Wrapper\PermissionHelper(0, 0)); //forcing user to root
 
         chown($fs->path('/'), 'root');
         $this->assertEquals('root', posix_getpwuid(fileowner($fs->path('/')))['name']);
@@ -122,6 +123,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
         }
 
         $fs = new FileSystem();
+        $fs->container()->setPermissionHelper(new Wrapper\PermissionHelper(0, 0)); //forcing user to root
 
         chown($fs->path('/'), 0);
 
@@ -138,6 +140,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
         }
 
         $fs = new FileSystem();
+        $fs->container()->setPermissionHelper(new Wrapper\PermissionHelper(0, 0)); //forcing user to root
 
         //lets workout available group
         //this is needed to find string name of group root belongs to
@@ -157,6 +160,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
         }
 
         $fs = new FileSystem();
+        $fs->container()->setPermissionHelper(new Wrapper\PermissionHelper(0, 0)); //forcing user to root
 
         //lets workout available group
         $group = posix_getpwuid(0)['gid'];

--- a/tests/VirtualFileSystem/WrapperTest.php
+++ b/tests/VirtualFileSystem/WrapperTest.php
@@ -7,8 +7,13 @@ use VirtualFileSystem\Structure\File;
 
 class WrapperTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
-    {
+    protected $uid;
+    protected $gid;
+
+    public function setUp() {
+        $this->uid = function_exists('posix_getuid') ? posix_getuid() : 0;
+        $this->gid = function_exists('posix_getgid') ? posix_getgid() : 0;
+
         @$na['n/a']; //putting error in known state
     }
 
@@ -96,9 +101,9 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
 
     public function testChownByName()
     {
-        if (posix_getuid() == 0) {
+        if ($this->uid == 0) {
             $this->markTestSkipped(
-                'No point testing if user is already root. \Php unit shouldn\'t be run as root user.'
+                'No point testing if user is already root. \Php unit shouldn\'t be run as root user. (Unless you are a windows user!)'
             );
         }
 
@@ -116,7 +121,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
 
     public function testChownById()
     {
-        if (posix_getuid() == 0) {
+        if ($this->uid == 0) {
             $this->markTestSkipped(
                 'No point testing if user is already root. Php unit shouldn\'t be run as root user.'
             );
@@ -133,9 +138,9 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
 
     public function testChgrpByName()
     {
-        if (posix_getgid() == 0) {
+        if ($this->uid == 0) {
             $this->markTestSkipped(
-                'No point testing if group is already root. Php unit shouldn\'t be run as root group.'
+                'No point testing if group is already root. Php unit shouldn\'t be run as root group. (Unless you are on Windows - then we skip)'
             );
         }
 
@@ -153,9 +158,9 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
 
     public function testChgrpById()
     {
-        if (posix_getgid() == 0) {
+        if ($this->gid == 0) {
             $this->markTestSkipped(
-                'No point testing if group is already root. Php unit shouldn\'t be run as root group.'
+                'No point testing if group is already root. Php unit shouldn\'t be run as root group. (Unless you are on Windows - then we skip)'
             );
         }
 
@@ -830,7 +835,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($wr->stream_open($fs->path('/file'), 'a+', 0, $path));
 
         $file->chmod(0400);
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
         $file->chgrp(0);
         $this->assertTrue($wr->stream_open($fs->path('/file'), 'r', 0, $path));
         $this->assertFalse($wr->stream_open($fs->path('/file'), 'r+', 0, $path));
@@ -840,7 +845,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($wr->stream_open($fs->path('/file'), 'a+', 0, $path));
 
         $file->chmod(0200);
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
         $file->chgrp(0);
         $this->assertFalse($wr->stream_open($fs->path('/file'), 'r', 0, $path));
         $this->assertFalse($wr->stream_open($fs->path('/file'), 'r+', 0, $path));
@@ -850,7 +855,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($wr->stream_open($fs->path('/file'), 'a+', 0, $path));
 
         $file->chmod(0600);
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
         $file->chgrp(0);
         $this->assertTrue($wr->stream_open($fs->path('/file'), 'r', 0, $path));
         $this->assertTrue($wr->stream_open($fs->path('/file'), 'r+', 0, $path));
@@ -879,7 +884,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($wr->stream_open($fs->path('/dir'), 'a+', 0, $path));
 
         $file->chmod(0400);
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
         $file->chgrp(0);
         $this->assertTrue($wr->stream_open($fs->path('/dir'), 'r', 0, $path));
         $this->assertFalse($wr->stream_open($fs->path('/dir'), 'r+', 0, $path));
@@ -889,7 +894,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($wr->stream_open($fs->path('/dir'), 'a+', 0, $path));
 
         $file->chmod(0200);
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
         $file->chgrp(0);
         $this->assertFalse($wr->stream_open($fs->path('/dir'), 'r', 0, $path));
         $this->assertFalse($wr->stream_open($fs->path('/dir'), 'r+', 0, $path));
@@ -899,7 +904,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($wr->stream_open($fs->path('/dir'), 'a+', 0, $path));
 
         $file->chmod(0600);
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
         $file->chgrp(0);
         $this->assertTrue($wr->stream_open($fs->path('/dir'), 'r', 0, $path));
         $this->assertFalse($wr->stream_open($fs->path('/dir'), 'r+', 0, $path));
@@ -922,18 +927,18 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(@$wr->dir_opendir($fs->path('/dir'), 0));
 
         $file->chmod(0200);
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
         $file->chgrp(0);
         $this->assertFalse(@$wr->dir_opendir($fs->path('/dir'), 0));
 
         $file->chmod(0400);
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
         $file->chgrp(0);
         $this->assertTrue(@$wr->stream_open($fs->path('/dir'), 'r', 0, $path));
 
         $file->chmod(0040);
         $file->chown(0);
-        $file->chgrp(posix_getgid());
+        $file->chgrp($this->gid);
         $this->assertTrue(@$wr->stream_open($fs->path('/dir'), 'r', 0, $path));
     }
 
@@ -1088,7 +1093,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
     {
         $fs = new FileSystem();
         $file = $fs->createFile('/file');
-        $file->chown(posix_getuid() + 1); //set to non current
+        $file->chown($this->uid + 1); //set to non current
 
         $wr = new Wrapper();
 
@@ -1109,7 +1114,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
     {
         $fs = new FileSystem();
         $file = $fs->createFile('/file');
-        $file->chown(posix_getuid() + 1); //set to non current
+        $file->chown($this->uid + 1); //set to non current
 
         $wr = new Wrapper();
 
@@ -1172,7 +1177,7 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
     {
         $fs = new FileSystem();
         $file = $fs->createFile('/file');
-        $file->chown(posix_getuid() + 1); //set to non current
+        $file->chown($this->uid + 1); //set to non current
         $file->chmod(0000);
 
         $wr = new Wrapper();
@@ -1189,14 +1194,14 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
             $error['message']
         );
 
-        $file->chown(posix_getuid());
+        $file->chown($this->uid);
 
         $this->assertTrue(
             $wr->stream_metadata($fs->path('/file'), STREAM_META_TOUCH, 0),
             'Allowed to touch if owner and no permission'
         );
 
-        $file->chown(posix_getuid() + 1); //set to non current
+        $file->chown($this->uid + 1); //set to non current
         $file->chmod(0002);
 
         $this->assertTrue(


### PR DESCRIPTION
Not sure how possible this is, but mocking on Windows immediately fails since functions like `posix_getuid` and `posix_getgid` do not exist. Any plans on supporting Windows? I switch between OSs, so this would be nice.
