### PR TITLE
Structure recreate support

### DIFF
--- a/src/VirtualFileSystem/Container.php
+++ b/src/VirtualFileSystem/Container.php
@@ -186,6 +186,22 @@ class Container
     }
 
     /**
+     * Creates struture
+     *
+     * @param array $structure
+     */
+    public function createStructure(array $structure, $parent = '/') {
+        foreach($structure as $key => $value) {
+            if(is_array($value)) {
+                $this->createDir($parent.$key);
+                $this->createStructure($value, $parent.$key.'/');
+            } else {
+                $this->createFile($parent.$key, $value);
+            }
+        }
+    }
+
+    /**
      * Moves Node from source to destination
      *
      * @param string $from

--- a/src/VirtualFileSystem/FileSystem.php
+++ b/src/VirtualFileSystem/FileSystem.php
@@ -151,4 +151,14 @@ class FileSystem
     {
         return $this->container()->createFile($path, $data);
     }
+
+    /**
+     * Creates fs structure
+     *
+     * @param array $structure
+     */
+    public function createStructure(array $structure)
+    {
+        $this->container()->createStructure($structure);
+    }
 }

--- a/tests/VirtualFileSystem/VirtualFilesystemTest.php
+++ b/tests/VirtualFileSystem/VirtualFilesystemTest.php
@@ -98,4 +98,51 @@ class VirtualFilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/file', $file->path());
         $this->assertEquals('data', $file->data());
     }
+
+    public function testCreateStuctureMirrorsStructure()
+    {
+        $fs = new FileSystem();
+        $fs->createStructure(['file' => 'omg', 'file2' => 'gmo']);
+
+        $file = $fs->container()->fileAt('/file');
+        $file2 = $fs->container()->fileAt('/file2');
+
+        $this->assertEquals('omg', $file->data());
+        $this->assertEquals('gmo', $file2->data());
+
+        $fs->createStructure(['dir' => [], 'dir2' => []]);
+
+        $dir = $fs->container()->fileAt('/dir');
+        $dir2 = $fs->container()->fileAt('/dir2');
+
+        $this->assertInstanceOf('VirtualFileSystem\Structure\Directory', $dir);
+        $this->assertInstanceOf('VirtualFileSystem\Structure\Directory', $dir2);
+
+        $fs->createStructure([
+            'dir3' => [
+                'file' => 'nested',
+                'dir4' => [
+                    'dir5' => [
+                        'file5' => 'nestednested'
+                    ]
+                ]
+            ]
+        ]);
+
+        $dir = $fs->container()->fileAt('/dir3');
+
+        $this->assertInstanceOf('VirtualFileSystem\Structure\Directory', $dir);
+
+        $file = $fs->container()->fileAt('/dir3/file');
+
+        $this->assertEquals('nested', $file->data());
+
+        $dir = $fs->container()->fileAt('/dir3/dir4/dir5');
+
+        $this->assertInstanceOf('VirtualFileSystem\Structure\Directory', $dir);
+
+        $file = $fs->container()->fileAt('/dir3/dir4/dir5/file5');
+
+        $this->assertEquals('nestednested', $file->data());
+    }
 }


### PR DESCRIPTION
@milesj in #15 mentioned following:

---

On a side note, it would be nice to have a method like `createStructure()` that can easily create nested files and folders.

```
$vfs->createStructure([
    'folder1' => [
        'file1.txt' => 'contents',
        'file2.php' => '<?php',
        'folder2' => []
    ]
]);
```

---
