### PR TITLE
Implement streamWrapper::stream_flush() to ensure fflush() returns TRUE

### DIFF
--- a/src/VirtualFileSystem/Wrapper.php
+++ b/src/VirtualFileSystem/Wrapper.php
@@ -322,6 +322,18 @@ class Wrapper
     }
 
     /**
+     * Flushes the output. This always returns TRUE, since no buffering takes place in FileHandler.
+     *
+     * @see http://php.net/streamwrapper.stream-flush
+     *
+     * @return bool
+     */
+    public function stream_flush()
+    {
+        return true;
+    }
+
+    /**
      * Called in response to mkdir to create directory.
      *
      * @see http://php.net/streamwrapper.mkdir

--- a/tests/VirtualFileSystem/WrapperTest.php
+++ b/tests/VirtualFileSystem/WrapperTest.php
@@ -288,6 +288,15 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testStreamFlushing()
+    {
+        $fs = new FileSystem();
+
+        $handle = fopen($fs->path('/file'), 'w');
+
+        $this->assertTrue(fflush($handle));
+    }
+
     public function testOpeningForReadingOnNonExistingFails()
     {
         $fs = new FileSystem();


### PR DESCRIPTION
I was using this to test some code that was calling [fflush](https://secure.php.net/fflush) and checking the result - `false` implies failure to flush. streamWrapper permits `stream_flush` to be implemented to indicate the result of a flush - without it, `false` is returned. Since no buffering takes place here, I've just made it always return true. Let me know if you have different thoughts about that! Also, the test is a bit pointless, but perhaps for the coverage.. :)
