### PR TITLE
clear stat cache after remove

### DIFF
--- a/src/VirtualFileSystem/Container.php
+++ b/src/VirtualFileSystem/Container.php
@@ -336,6 +336,8 @@ class Container
         }
 
         $this->directoryAt(dirname($path))->remove(basename($path));
+
+        clearstatcache(true, $path);
     }
 
     /**

--- a/tests/VirtualFileSystem/WrapperTest.php
+++ b/tests/VirtualFileSystem/WrapperTest.php
@@ -1525,4 +1525,34 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(5, filesize($file));
     }
 
+    public function testRmdirAfterUrlStatCall()
+    {
+        $fs = new FileSystem();
+
+        $path = $fs->path('dir');
+
+        mkdir($path);
+
+        $this->assertFileExists($path);
+
+        rmdir($path);
+
+        $this->assertFileNotExists($path);
+    }
+
+    public function testUnlinkAfterUrlStatCall()
+    {
+        $fs = new FileSystem();
+
+        $path = $fs->path('file');
+
+        touch($path);
+
+        $this->assertFileExists($path);
+
+        unlink($path);
+
+        $this->assertFileNotExists($path);
+    }
+
 }


### PR DESCRIPTION
`url_stat` calls are cached so node removal had inconsistent behaviour.
