### PR TITLE
The wrapper should consider $time and $atime arguments of touch()

### DIFF
--- a/src/VirtualFileSystem/Wrapper.php
+++ b/src/VirtualFileSystem/Wrapper.php
@@ -427,9 +427,12 @@ class Wrapper
                     return false;
                 }
 
-                $file->setAccessTime(time());
-                $file->setModificationTime(time());
-                $file->setChangeTime(time());
+                $time = isset($value[0]) ? $value[0] : time();
+                $atime = isset($value[1]) ? $value[1] : $time;
+
+                $file->setChangeTime($time);
+                $file->setModificationTime($time);
+                $file->setAccessTime($atime);
 
                 clearstatcache(true, $path);
 

--- a/tests/VirtualFileSystem/WrapperTest.php
+++ b/tests/VirtualFileSystem/WrapperTest.php
@@ -537,6 +537,21 @@ class WrapperTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testTouchUpdatesTimes()
+    {
+        $fs = new FileSystem();
+        $path = $fs->path('/file');
+
+        $time = 1500020720;
+        $atime = 1500204791;
+
+        touch($path, $time, $atime);
+
+        $this->assertEquals($time, filectime($path));
+        $this->assertEquals($time, filemtime($path));
+        $this->assertEquals($atime, fileatime($path));
+    }
+
     public function testRenamesMovesFileCorrectly()
     {
         $fs = new FileSystem();


### PR DESCRIPTION
The 2nd and 3rd arguments of `touch()` are currently ignored by the VFS wrapper, and the actual value of `time()` is used instead. It makes it impossible to change `[acm]time` using `touch()`.