### PR TITLE
Set the stream name via environment variable

### DIFF
--- a/src/VirtualFileSystem/FileSystem.php
+++ b/src/VirtualFileSystem/FileSystem.php
@@ -39,7 +39,7 @@ class FileSystem
      */
     public function __construct()
     {
-        $this->scheme = uniqid('phpvfs');
+        $this->scheme = isset($_ENV['PHPVFS_NAME']) ? $_ENV['PHPVFS_NAME'] : uniqid('phpvfs');
 
         /* injecting components */
         $this->container = $container = new Container(new Factory());

--- a/tests/VirtualFileSystem/VirtualFilesystemTest.php
+++ b/tests/VirtualFileSystem/VirtualFilesystemTest.php
@@ -61,7 +61,17 @@ class VirtualFilesystemTest extends \PHPUnit\Framework\TestCase
 
     }
 
+    public function testSetStreamNameViaEnvironmentVariable()
+    {
+        $_ENV['PHPVFS_NAME'] = 'vfs';
 
+        $fs = new FileSystem();
+        $fs->createFile('/foo.txt', 'This is the content of foo.txt');
+
+        $this->assertEquals('vfs://foo.txt', $fs->path('foo.txt'));
+
+        unset($_ENV['PHPVFS_NAME']);
+    }
 
     public function testCreateDirectoryCreatesDirectories()
     {


### PR DESCRIPTION
Add the possibility to define a personalized stream name via `$_ENV['PHPVFS_NAME']` environment variable.

It's useful in all those cases when we want to hardcode urls.
Let's suppose to have a class which reads the name of a directory from a configuration file (eg. `config.ini`):
```ini
app_dir=/my/awesome/dir
``` 
When I'm testing this class, it could be useful to define a virtual directory name in a `fixtures/config.ini` file in such way:
```ini
app_dir=myvfs://my/awesome/dir
```
Before this commit, it's almost impossible because the name of the stream is unique and based on microtime, so it can't be hardcoded. With this commit, it's enough to write in `phpunit.xml`:
```xml
...
<php>
    <env name="PHPVFS_NAME" value="myvfs" />
</php>
....
```