### PR TITLE
Fixed some issues specific to PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4snapshot
 
 cache:
   directories:
@@ -15,8 +17,8 @@ cache:
 
 before_script: 
   - composer self-update
-  - composer install --dev --no-interaction --prefer-dist
+  - composer install --no-interaction --prefer-dist
 
 script:
   - mkdir -p build/logs
-  - phpunit
+  - vendor/bin/phpunit

--- a/src/VirtualFileSystem/Wrapper.php
+++ b/src/VirtualFileSystem/Wrapper.php
@@ -243,12 +243,12 @@ class Wrapper
      *
      * @param $data
      *
-     * @return false|integer
+     * @return integer
      */
     public function stream_write($data)
     {
         if (!$this->currentlyOpenedFile->isOpenedForWriting()) {
-            return false;
+            return 0;
         }
         //file access time changes so stat cache needs to be cleared
         $written = $this->currentlyOpenedFile->write($data);
@@ -496,7 +496,17 @@ class Wrapper
 
                         return false;
                     }
-                    $uid = function_exists('posix_getpwnam') ? posix_getpwnam($value)['uid'] : 0;
+
+                    $uid = 0;
+
+                    if (function_exists('posix_getpwnam')) {
+                        $user = posix_getpwnam($value);
+
+                        if ($user !== false) {
+                            $uid = $user['uid'];
+                        }
+                    }
+
                     $node->chown($uid);
                     $node->setChangeTime(time());
                     break;
@@ -523,7 +533,17 @@ class Wrapper
 
                         return false;
                     }
-                    $gid = function_exists('posix_getgrnam') ? posix_getgrnam($value)['gid'] : 0;
+
+                    $gid = 0;
+
+                    if (function_exists('posix_getgrnam')) {
+                        $group = posix_getgrnam($value);
+
+                        if ($group !== false) {
+                            $gid = $group['gid'];
+                        }
+                    }
+
                     $node->chgrp($gid);
                     $node->setChangeTime(time());
                     break;
@@ -815,5 +835,10 @@ class Wrapper
     public function stream_lock($operation)
     {
         return $this->currentlyOpenedFile->lock($this, $operation);
+    }
+
+    public function stream_set_option($option, $arg1, $arg2)
+    {
+        return false;
     }
 }

--- a/tests/VirtualFileSystem/WrapperTest.php
+++ b/tests/VirtualFileSystem/WrapperTest.php
@@ -1581,4 +1581,15 @@ class WrapperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals("image/gif", $finfo->file($fs->path('/file.gif')));
 
     }
+
+    public function testRequire()
+    {
+        $fs = new FileSystem();
+        $fs->createFile('/file.php', <<<'PHP'
+<?php return 1;
+PHP
+        );
+
+        $this->assertSame(1, require $fs->path('/file.php'));
+    }
 }


### PR DESCRIPTION
According to https://www.php.net/streamwrapper.stream-write, the method

> Should return the number of bytes that were successfully stored, or 0 if none could be stored.

Relevant changes in PHP:

1. https://github.com/php/php-src/commit/a986e70991057785cd3e5f4235215cb933351b4d
2. https://wiki.php.net/rfc/notice-for-non-valid-array-container

Additionally:

1. Added PHP 7.3 and 7.4snapshot to the build matrix.
2. Removed the usage of the deprecated Composer `--dev` option.
3. In `.travis.yaml`, replaced the call to `phpunit` with `vendor/bin/phpunit` in order to use the vendored PHPUnit 6.5 which is compatible with PHP 7.0.