### PR TITLE
Test enhancement stuffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 cache:
   directories:
     - $HOME/.composer/cache
 
-before_script: 
+before_script:
   - composer self-update
   - composer install --no-interaction --prefer-dist
 

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
+        "php": ">=7.0",
         "sami/sami": "*",
         "phpunit/phpunit": "^6.5",
         "doctrine/instantiator": "~1.0.2"


### PR DESCRIPTION
# Changed loh
- The `php-7.4` version is available on Travis CI build. Using the `php-7.4` version diectly.
- Removing additional white space on `before_script` section.
- According to the `composer.lock` file, it seems that the test building is only available on `php-7.0+` versions.
Setting the `"php": ">=7.0"` definition on `require-dev` block is required.