### PR TITLE
Properly bumped license to MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Very simple filesystem emulating PHP stream wrapper for use in unit testing
 with PHPUnit, PHPSpec or any other testing framework. It offers means to test methods interacting
 with real filesystem without creating temportary directories or file fixtures.
 
-Released under a GPL3+ licence.
+Released under a MIT licence.
 
 For latest release please use tag indicated above.
 

--- a/build/pear/package.tpl
+++ b/build/pear/package.tpl
@@ -22,7 +22,7 @@
         <release>stable</release>
         <api>stable</api>
     </stability>
-    <license uri="http://opensource.org/licenses/GPL-3.0">GPL3+</license>
+    <license uri="https://opensource.org/licenses/MIT">MIT</license>
     <notes>-</notes>
     <dependencies>
         <required>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "php-vfs/php-vfs",
     "homepage": "http://michael-donat.github.com/php-vfs",
     "keywords": ["php", "virtual", "filesystem", "testing", "unit"],
-    "license": "GPL-3.0+",
+    "license": "MIT",
     "description": "Virtual file system implementation for use with PHP unit testing.",
     "minimum-stability": "stable",
     "authors": [


### PR DESCRIPTION
I noticed that the license headers are bumped but not the internals. With this PR all is marked as MIT

Would be great if we could release it since it was intended to be MIT however on our end the package is blocked at an install since the fact it is not licensed properly.