### PR TITLE
fix(php): fix compatibility issue with php 8.1

### DIFF
--- a/src/VirtualFileSystem/Wrapper/FileHandler.php
+++ b/src/VirtualFileSystem/Wrapper/FileHandler.php
@@ -149,7 +149,7 @@ class FileHandler
     public function truncate($newSize = 0)
     {
         $this->position(0);
-        $newData = substr($this->file->data(), 0, $newSize);
+        $newData = substr($this->file->data() ? $this->file->data() : '', 0, $newSize);
         $newData = false === $newData ? '' : $newData;
         $this->file->setData($newData);
         $this->file->setModificationTime(time());

--- a/src/VirtualFileSystem/Wrapper/FileHandler.php
+++ b/src/VirtualFileSystem/Wrapper/FileHandler.php
@@ -149,7 +149,7 @@ class FileHandler
     public function truncate($newSize = 0)
     {
         $this->position(0);
-        $newData = substr($this->file->data() ? $this->file->data() : '', 0, $newSize);
+        $newData = substr($this->file->data() ?? '', 0, $newSize);
         $newData = false === $newData ? '' : $newData;
         $this->file->setData($newData);
         $this->file->setModificationTime(time());


### PR DESCRIPTION
avoid `substr(): Passing null to parameter #1 ($string) of type string is deprecated`